### PR TITLE
Links in navbar

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,3 +17,7 @@
     <%= render 'shared/footer' %>
   </body>
 </html>
+
+<!-- if current user not connected => sign-up: new_user_registration_path
+
+if current user's signed in => dashboard: dashboard_path -->

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -10,7 +10,14 @@
     </div>
     <div class="row">
       <div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
-        <a href="" class="btn-freeletics">Commencer maintenant !</a>
+        <!-- if current user not connected => sign-up: new_user_registration_path -->
+        <% if !user_signed_in? %>
+            <%= link_to "Commencer maintenant !", new_user_registration_path, class: "btn-freeletics" %>
+        <!-- if current user's signed in => dashboard: dashboard_path -->
+          <% else %>
+             <%= link_to "Commencer maintenant !", dashboard_path, class: "btn-freeletics" %>
+        <% end %>
+  <!--         <a href="" class="btn-freeletics">Commencer maintenant !</a> -->
       </div>
     </div>
   </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -7,14 +7,6 @@
   <!-- Right Navigation -->
   <div class="navbar-wagon-right hidden-xs hidden-sm">
 
-    <!-- Search form -->
-  <!--   <form action="" class="navbar-wagon-search">
-      <input type="text" class="navbar-wagon-search-input" placeholder="Search something">
-      <button type="submit" class="navbar-wagon-search-btn">
-        <i class="fa fa-search"></i>
-      </button>
-    </form> -->
-
     <!-- Different navigation if login or not -->
     <% if user_signed_in? %>
 
@@ -32,12 +24,12 @@
           <%= image_tag "avatar.png", class: "avatar dropdown-toggle", id: "navbar-wagon-menu", "data-toggle" => "dropdown" %>
           <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
             <li>
-              <%= link_to "#" do %>
-                <i class="fa fa-user"></i> <%= t(".profile", default: "Profil") %>
+              <%= link_to dashboard_path do %>
+                <i class="fa fa-user"></i> <%= t(".profile", default: "Dashboard") %>
               <% end %>
             </li>
             <li>
-              <%= link_to "#" do %>
+              <%= link_to root_path do %>
                 <i class="fa fa-home"></i>  <%= t(".profile", default: "Accueil") %>
               <% end %>
             </li>
@@ -61,7 +53,7 @@
       <% end %>
 
       <!-- Button (call-to-action) -->
-      <%= link_to t(".top_call_to_action", default: "Créer un groupe"), "#", class: "navbar-wagon-item navbar-wagon-button btn" %>
+      <%= link_to t(".top_call_to_action", default: "Créer un groupe"), dashboard_path, class: "navbar-wagon-item navbar-wagon-button btn" %>
   </div>
 
   <!-- Dropdown list appearing on mobile only -->
@@ -69,9 +61,8 @@
     <div class="dropdown">
       <i class="fa fa-bars dropdown-toggle" data-toggle="dropdown"></i>
       <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
-        <li><a href="#">Some mobile link</a></li>
-        <li><a href="#">Other one</a></li>
-        <li><a href="#">Other one</a></li>
+          <li><%= link_to "Dashboard", dashboard_path %></li>
+          <li><%= link_to "Log out", destroy_user_session_path, method: :delete %></li>
       </ul>
     </div>
   </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -25,17 +25,22 @@
           <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
             <li>
               <%= link_to dashboard_path do %>
-                <i class="fa fa-user"></i> <%= t(".profile", default: "Dashboard") %>
+                <i class="fa fa-tachometer"></i> <%= t(".dashboard_", default: "Dashboard") %>
               <% end %>
             </li>
             <li>
               <%= link_to root_path do %>
-                <i class="fa fa-home"></i>  <%= t(".profile", default: "Accueil") %>
+                <i class="fa fa-user"></i>  <%= t(".profile", default: "Profile") %>
+              <% end %>
+            </li>
+            <li>
+              <%= link_to root_path do %>
+                <i class="fa fa-home"></i>  <%= t(".home", default: "Home") %>
               <% end %>
             </li>
             <li>
               <%= link_to destroy_user_session_path, method: :delete do %>
-                <i class="fa fa-sign-out"></i>  <%= t(".sign_out", default: "Se deconnecter") %>
+                <i class="fa fa-sign-out"></i>  <%= t(".sign_out", default: "Sign-out") %>
               <% end %>
             </li>
           </ul>
@@ -61,8 +66,8 @@
     <div class="dropdown">
       <i class="fa fa-bars dropdown-toggle" data-toggle="dropdown"></i>
       <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
-          <li><%= link_to "Dashboard", dashboard_path %></li>
-          <li><%= link_to "Log out", destroy_user_session_path, method: :delete %></li>
+          <li><%= link_to t(".dashboard_", default: "Dashboard"), dashboard_path %></li>
+          <li><%= link_to t(".sign_out", default: "Sign-out"), destroy_user_session_path, method: :delete %></li>
       </ul>
     </div>
   </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -25,11 +25,11 @@
           <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
             <li>
               <%= link_to dashboard_path do %>
-                <i class="fa fa-tachometer"></i> <%= t(".dashboard_", default: "Dashboard") %>
+                <i class="fa fa-tachometer"></i> <%= t(".dashboard", default: "Dashboard") %>
               <% end %>
             </li>
             <li>
-              <%= link_to root_path do %>
+              <%= link_to dashboard_path do %>
                 <i class="fa fa-user"></i>  <%= t(".profile", default: "Profile") %>
               <% end %>
             </li>
@@ -66,7 +66,8 @@
     <div class="dropdown">
       <i class="fa fa-bars dropdown-toggle" data-toggle="dropdown"></i>
       <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
-          <li><%= link_to t(".dashboard_", default: "Dashboard"), dashboard_path %></li>
+          <li><%= link_to t(".dashboard", default: "Dashboard"), dashboard_path %></li>
+          <li><%= link_to t(".profile", default: "Profile"), dashboard_path %></li>
           <li><%= link_to t(".sign_out", default: "Sign-out"), destroy_user_session_path, method: :delete %></li>
       </ul>
     </div>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,7 @@
+fr:
+  shared:
+    navbar:
+      dashboard: "Tableau de bord"
+      profile: "Profil"
+      home: "Accueil"
+      sign_out: "Se déconnecter"


### PR DESCRIPTION
According to the plan
Je propose de commencer par un petit relifting des liens navbars et HP pour que ce soit fonctionnel pour demain et notamment:
-en mode déconnecté
  *de renvoyer le bouton Commencez maintenant vers la création de compte
  *et le créer un groupe => créer un compte
-quand on se crée un compte ou se loggin => de renvoyer vers le dashboard
-en mode connecté, de mettre dans le dropdown: d’abord un lien vers le dashboard, ensuite sur le profil, puis la HP publique et un dernier vers la déconnexion.
et de renvoyer le bouton commencer de la HP vers le dashboard

NB: j'ai rajouté comme prévu un lien vers une page profil (qui renvoie pour l'instant sur le dashboard)