### PR TITLE
Format cours de date qui sinon dépasse dans la dashboard de la carte …

### DIFF
--- a/app/views/pages/_slot_info.html.erb
+++ b/app/views/pages/_slot_info.html.erb
@@ -2,7 +2,7 @@
   <p>
     <i class="fa fa-calendar" id="calendar-icon">
     </i>
-    <p class="text-date"><%= l(slot.date, format: :long) %></p>
+    <p class="text-date"><%= l(slot.date, format: :medium) %></p>
   </p>
   <p>
     <i class="fa fa-clock-o" id="clock-icon"></i>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -47,6 +47,7 @@ fr:
     formats:
       default: "%d/%m/%Y"
       short: "%e %b"
+      medium: "%a %e %b %Y"
       long: "%A %e %B %Y"
     month_names:
     -


### PR DESCRIPTION
…pour les dates longues. Création d’un nouveau format pour ne pas avoir d’autres impacts

avant (sur la prod) et après (en local)

![capture d ecran 2017-06-01 a 22 09 32](https://cloud.githubusercontent.com/assets/22742423/26699274/78cf04ec-4719-11e7-96a6-93e5b902659d.png)

![capture d ecran 2017-06-01 a 22 09 22](https://cloud.githubusercontent.com/assets/22742423/26699300/9acd99aa-4719-11e7-8918-6a0d1d74a582.png)
